### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/run.py
+++ b/run.py
@@ -19,7 +19,7 @@ def main(argv):
             tune_name='huanxisha', rhyme='ang', data_source_dao=mongo_dao)
         for i in range(5):
             title, content = songci_writer.write_new()
-            print('\n《%s》\n\n%s\n\n' % (title, content))
+            print('\n《{0!s}》\n\n{1!s}\n\n'.format(title, content))
 
 
 if __name__ == '__main__':

--- a/writer/songci_writer.py
+++ b/writer/songci_writer.py
@@ -22,7 +22,7 @@ class WordPattern:
     def fetch_word(self, data_source_dao) -> (str, int):
         where = {}
         if self.tones_regex:
-            where["finals.tones"] = re.compile('^%s$' % self.tones_regex)
+            where["finals.tones"] = re.compile('^{0!s}$'.format(self.tones_regex))
         if self.rhyme:
             where["finals.rhyme"] = self.rhyme
 
@@ -47,7 +47,7 @@ class SongciWriter:
     def write_new(self) -> (str, str):
         if not self._tune.pattern:
             raise ValueError(
-                'pattern for tune [%s] is empty.' % self.tune_name)
+                'pattern for tune [{0!s}] is empty.'.format(self.tune_name))
         self._analyze()
 
         with StringIO() as songci_io:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:wings27:songci?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:wings27:songci?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)